### PR TITLE
feat: handle MissingServletRequestParameterException as bad request

### DIFF
--- a/src/main/kotlin/com/ekino/oss/errors/handler/CoreExceptionHandler.kt
+++ b/src/main/kotlin/com/ekino/oss/errors/handler/CoreExceptionHandler.kt
@@ -19,6 +19,7 @@ import org.springframework.validation.BindException
 import org.springframework.validation.BindingResult
 import org.springframework.web.HttpRequestMethodNotSupportedException
 import org.springframework.web.bind.MethodArgumentNotValidException
+import org.springframework.web.bind.MissingServletRequestParameterException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestControllerAdvice
@@ -94,6 +95,14 @@ abstract class CoreExceptionHandler(
     log.debug("Argument type mismatch : ", e)
     return toErrorResponse(badRequest(
       buildServiceName(req, applicationName), "error.argument_type_mismatch", e.message, e.toStacktrace(properties.displayFullStacktrace)
+    ))
+  }
+
+  @ExceptionHandler(MissingServletRequestParameterException::class)
+  fun handleMissingServletRequestParameterException(req: HttpServletRequest, e: MissingServletRequestParameterException): ResponseEntity<ErrorBody> {
+    log.debug("Missing parameter : ", e)
+    return toErrorResponse(badRequest(
+      buildServiceName(req, applicationName), "error.missing_parameter", e.message, e.toStacktrace(properties.displayFullStacktrace)
     ))
   }
 

--- a/src/test/kotlin/com/ekino/oss/errors/RestExceptionHandlerTest.kt
+++ b/src/test/kotlin/com/ekino/oss/errors/RestExceptionHandlerTest.kt
@@ -1,6 +1,7 @@
 package com.ekino.oss.errors
 
 import org.hamcrest.Matchers.`is`
+import org.hamcrest.Matchers.empty
 import org.hamcrest.Matchers.hasSize
 import org.hamcrest.Matchers.isEmptyOrNullString
 import org.hamcrest.Matchers.not
@@ -18,6 +19,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.util.UUID
 
 const val ROOT_PATH = API_PATH
 const val RESOLVED_ERROR_PATH = API_PATH + ERROR_PATH
@@ -31,8 +33,20 @@ class RestExceptionHandlerTest {
 
   @Test
   fun should_get_ok_response() {
-    mockMvc.perform(get("$ROOT_PATH/ok"))
+    mockMvc.perform(get("$ROOT_PATH/ok?id=${UUID.randomUUID()}"))
       .andExpect(status().isOk)
+  }
+
+  @Test
+  fun should_get_missing_parameter_error() {
+    mockMvc.perform(get("$ROOT_PATH/ok"))
+      .andExpect(status().isBadRequest)
+      .andExpect(jsonPath("$.status", `is`(HttpStatus.BAD_REQUEST.value())))
+      .andExpect(jsonPath("$.code", `is`("error.missing_parameter")))
+      .andExpect(jsonPath("$.message", `is`(HttpStatus.BAD_REQUEST.reasonPhrase)))
+      .andExpect(jsonPath("$.description", not(isEmptyOrNullString())))
+      .andExpect(jsonPath("$.errors", empty<Any>()))
+      .andExpect(jsonPath("$.service", `is`("myApp : GET /test/ok")))
   }
 
   @Test

--- a/src/test/kotlin/com/ekino/oss/errors/TestResource.kt
+++ b/src/test/kotlin/com/ekino/oss/errors/TestResource.kt
@@ -30,7 +30,7 @@ const val ERROR_MESSAGE = "Message for developers"
 class TestResource {
 
   @GetMapping("/ok")
-  fun getOk(@RequestParam id: UUID?): ResponseEntity<String> = ResponseEntity.ok("OK")
+  fun getOk(@RequestParam id: UUID): ResponseEntity<String> = ResponseEntity.ok("OK")
 
   @PostMapping("/ok")
   fun postOk(@RequestBody @Valid body: PostBody): ResponseEntity<String> = ResponseEntity.ok(body.message!!)


### PR DESCRIPTION
Fix https://github.com/ekino/spring-boot-starter-errors/issues/10

While it's a breaking change, version has been bumped to 2.0.0-SNAPSHOT.